### PR TITLE
Ajuste para permitir abrir o dashboard sem agente cadastrado

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -13,7 +13,11 @@ def home(request):
     graphic_product_brand_metric = metrics.get_graphic_product_brand_metric()
     daily_sales_data = metrics.get_daily_sales_data()
     daily_sales_quantity_data = metrics.get_daily_sales_quantity_data()
-    ai_result = AIResult.objects.first().result
+    ai_result = AIResult.objects.first()
+    if ai_result is not None:
+        ai_result = ai_result.result
+    else:
+        ai_result = 'Nenhum agente disponível'
 
     context = {
         'product_metrics': product_metrics,


### PR DESCRIPTION
Ao baixar e executar o projeto na máquina, não estava permitindo abrir o dashboard por conta do erro abaixo. Apenas adicionei uma trativa no "app/views.py" para que caso não tenha nenhum registro, preencha o campo com "Nenhum agente disponível".

Traceback (most recent call last):
  File "C:\Fontes\sge\venv\Lib\site-packages\django\core\handlers\exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Fontes\sge\venv\Lib\site-packages\django\core\handlers\base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Fontes\sge\venv\Lib\site-packages\django\contrib\auth\decorators.py", line 23, in _wrapper_view
    return view_func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Fontes\sge\app\views.py", line 16, in home
    ai_result = AIResult.objects.first().result
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Exception Type: AttributeError at /
Exception Value: 'NoneType' object has no attribute 'result'

