### PR TITLE
refactor permissions: replace DjangoModelPermissions with CustomDjang…

### DIFF
--- a/app/permissions.py
+++ b/app/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework import permissions
+
+class CustomDjangoModelPermission(permissions.DjangoModelPermissions):
+    # Override to improve the permissions on API
+    perms_map = {
+        'GET': ['%(app_label)s.view_%(model_name)s'],     
+        'OPTIONS': [],
+        'HEAD': [],
+        'POST': ['%(app_label)s.add_%(model_name)s'],
+        'PUT': ['%(app_label)s.change_%(model_name)s'],
+        'PATCH': ['%(app_label)s.change_%(model_name)s'],
+        'DELETE': ['%(app_label)s.delete_%(model_name)s'],
+    }

--- a/app/settings.py
+++ b/app/settings.py
@@ -155,7 +155,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
-        'rest_framework.permissions.DjangoModelPermissions',
+        'app.permissions.CustomDjangoModelPermission'  #  Improve permissions to view in DRF
     ),
 }
 


### PR DESCRIPTION
By default, DjangoModelPermissions allows access to "safe" methods (GET, HEAD, OPTIONS). A custom class was created to override the 'perms_map' property and include the permission in the GET method. for improved API access control